### PR TITLE
READ処理の実装

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM mysql:8.0-debian
+RUN apt-get update
+RUN apt-get -y install locales-all
+ENV LANG ja_JP.UTF-8
+ENV LANGUAGE ja_JP:ja
+ENV LC_ALL ja_JP.UTF-8
+COPY ./conf/mysql/my.cnf /etc/my.cnf

--- a/conf/mysql/my.cnf
+++ b/conf/mysql/my.cnf
@@ -1,0 +1,11 @@
+[mysqld]
+skip-character-set-client-handshake
+default-time-zone='+9:00'
+character-set-server = utf8mb4
+collation-server = utf8mb4_general_ci
+slow_query_log = 1
+slow_query_log_file = /var/log/slow_query.log
+long_query_time = 1
+
+[client]
+default-character-set = utf8mb4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  db:
+    build: .
+    container_name: docker-mysql-boxer
+    platform: linux/x86_64
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: boxer_db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - 3307:3306
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d
+      - my-vol:/var/lib/mysql
+volumes:
+  my-vol:

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS boxerdata;
+
+CREATE TABLE boxerdata
+(
+  id INT UNSIGNED AUTO_INCREMENT,
+  name VARCHAR(100) NOT NULL,
+  number_of_matches INT NOT NULL,
+  win INT NOT NULL,
+  ko INT NOT NULL,
+  loss INT NOT NULL,
+  draw INT NOT NULL,
+  PRIMARY KEY(id)
+);
+
+INSERT INTO boxerdata (name, number_of_matches,win, ko, loss,draw)VALUES ('Inoue Naoya', 27,27, 24,0,0);
+INSERT INTO boxerdata (name, number_of_matches,win, ko, loss,draw)VALUES ('Hasegawa Hozumi',41,36, 16, 5,0);
+INSERT INTO boxerdata (name, number_of_matches,win, ko, loss,draw)VALUES ('Yaegashi Azuma', 35, 28, 16,7,0);
+INSERT INTO boxerdata (name, number_of_matches,win, ko, loss,draw)VALUES ('Yamanaka Shinsuke', 31, 27, 19,2,2);
+INSERT INTO boxerdata (name, number_of_matches,win, ko, loss,draw)VALUES ('Uchiyama takashi', 27, 24, 20,2,1);

--- a/src/main/java/com/example/boxinglist/Boxer.java
+++ b/src/main/java/com/example/boxinglist/Boxer.java
@@ -1,0 +1,80 @@
+package com.example.boxinglist;
+
+public class Boxer {
+    private int id;
+
+    private String name;
+
+    private int numberOfMatches;
+
+    private int win;
+    private int ko;
+    private int loss;
+    private int draw;
+
+    public Boxer(int id, String name, int numberOfMatches, int win, int ko, int loss, int draw) {
+        this.id = id;
+        this.name = name;
+        this.numberOfMatches = numberOfMatches;
+        this.win = win;
+        this.ko = ko;
+        this.loss = loss;
+        this.draw = draw;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getNumberOfMatches() {
+        return numberOfMatches;
+    }
+
+    public int getWin() {
+        return win;
+    }
+
+    public int getKo() {
+        return ko;
+    }
+
+    public int getLoss() {
+        return loss;
+    }
+
+    public int getDraw() {
+        return draw;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setNumberOfMatches(int numberOfMatches) {
+        this.numberOfMatches = numberOfMatches;
+    }
+
+    public void setWin(int win) {
+        this.win = win;
+    }
+
+    public void setKo(int ko) {
+        this.ko = ko;
+    }
+
+    public void setLoss(int loss) {
+        this.loss = loss;
+    }
+
+    public void setDraw(int draw) {
+        this.draw = draw;
+    }
+}

--- a/src/main/java/com/example/boxinglist/BoxingListController.java
+++ b/src/main/java/com/example/boxinglist/BoxingListController.java
@@ -1,0 +1,44 @@
+package com.example.boxinglist;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class BoxingListController {
+
+    private BoxingListService boxingListService;
+
+    public BoxingListController(BoxingListService boxingListService) {
+
+        this.boxingListService = boxingListService;
+    }
+
+    @GetMapping("/boxers")  //エンドポイント例 http://localhost:8080/boxers
+    public List<Boxer> getBoxers() {
+        List<Boxer> boxer = boxingListService.findAll();
+        return boxer;
+    }
+
+    @GetMapping("/findNames") //エンドポイント例 http://localhost:8080/findNames?startsWith=I
+    public List<Boxer> getBoxers(@RequestParam String startsWith) {
+        List<Boxer> boxers = boxingListService.findByNamesStartingWith(startsWith);
+        return boxers;
+    }
+
+    @GetMapping("/boxers/{id}") //エンドポイント例 http://localhost:8080/boxers/1
+    public Boxer findBoxer(@PathVariable("id") int id) {
+        return boxingListService.findBoxer(id);
+    }
+
+    @GetMapping("/boxers/findByMatches")
+    //エンドポイント例  http://localhost:8080/boxers/findByMatches?minMatches=40&maxMatches=50
+    public List<Boxer> getBoxersByMatches(@RequestParam int minMatches, @RequestParam int maxMatches) {
+        return boxingListService.findByNumberOfMatchesBetween(minMatches, maxMatches);
+    }
+
+}
+

--- a/src/main/java/com/example/boxinglist/BoxingListController.java
+++ b/src/main/java/com/example/boxinglist/BoxingListController.java
@@ -24,7 +24,7 @@ public class BoxingListController {
     }
 
     @GetMapping("/findNames") //エンドポイント例 http://localhost:8080/findNames?startsWith=I
-    public List<Boxer> getBoxers(@RequestParam String startsWith) {
+    public List<Boxer> findByNames(@RequestParam String startsWith) {
         List<Boxer> boxers = boxingListService.findByNamesStartingWith(startsWith);
         return boxers;
     }
@@ -41,4 +41,3 @@ public class BoxingListController {
     }
 
 }
-

--- a/src/main/java/com/example/boxinglist/BoxingListMapper.java
+++ b/src/main/java/com/example/boxinglist/BoxingListMapper.java
@@ -1,0 +1,24 @@
+package com.example.boxinglist;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface BoxingListMapper {
+    @Select("SELECT * FROM boxerdata")
+    List<Boxer> findAll();
+
+    @Select("SELECT * FROM boxerdata WHERE name LIKE CONCAT(#{prefix}, '%')")
+    List<Boxer> findByNamesStartingWith(String startsWith);
+
+    @Select("SELECT * FROM boxerdata WHERE id =#{id}")
+    Optional<Boxer> findById(int id);
+
+    @Select("SELECT * FROM boxerdata WHERE number_of_matches BETWEEN #{minMatches} AND #{maxMatches}")
+    List<Boxer> findByNumberOfMatchesBetween(@Param("minMatches") int minMatches, @Param("maxMatches") int maxMatches);
+
+}

--- a/src/main/java/com/example/boxinglist/BoxingListMapper.java
+++ b/src/main/java/com/example/boxinglist/BoxingListMapper.java
@@ -21,4 +21,5 @@ public interface BoxingListMapper {
     @Select("SELECT * FROM boxerdata WHERE number_of_matches BETWEEN #{minMatches} AND #{maxMatches}")
     List<Boxer> findByNumberOfMatchesBetween(@Param("minMatches") int minMatches, @Param("maxMatches") int maxMatches);
 
+
 }

--- a/src/main/java/com/example/boxinglist/BoxingListNotFoundException.java
+++ b/src/main/java/com/example/boxinglist/BoxingListNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.boxinglist;
+
+public class BoxingListNotFoundException extends RuntimeException {
+    public BoxingListNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/boxinglist/BoxingListService.java
+++ b/src/main/java/com/example/boxinglist/BoxingListService.java
@@ -18,7 +18,15 @@ public class BoxingListService {
     }
 
     public List<Boxer> findByNamesStartingWith(String startsWith) {
-        return boxingListMapper.findByNamesStartingWith(startsWith);
+        List<Boxer> boxers = boxingListMapper.findByNamesStartingWith(startsWith);
+        if (startsWith == null || startsWith.trim().isEmpty()) {
+            throw new BoxingListNotFoundException("空白入力では、Boxerは検索できません。");
+        }
+        if (boxers.isEmpty()) {
+            throw new BoxingListNotFoundException
+                    ("ボクシングリストに　" + startsWith + "　から始まる文字のBoxerは見つかりません。");
+        }
+        return boxers;
     }
 
     public Boxer findBoxer(int id) {
@@ -26,8 +34,11 @@ public class BoxingListService {
                 .orElseThrow(() -> new BoxingListNotFoundException("Boxer with id " + id + " not found"));
     }
 
-    public List<Boxer> findByNumberOfMatchesBetween(int minMatches, int maxMatches) {
-        return boxingListMapper.findByNumberOfMatchesBetween(minMatches, maxMatches);
+    public List<Boxer> findByNumberOfMatchesBetween(Integer minMatches, Integer maxMatches) {
+        List<Boxer> boxers = boxingListMapper.findByNumberOfMatchesBetween(minMatches, maxMatches);
+        if (boxers.isEmpty()) {
+            throw new BoxingListNotFoundException("指定された試合数範囲に該当するボクサーはいません。");
+        }
+        return boxers;
     }
-
 }

--- a/src/main/java/com/example/boxinglist/BoxingListService.java
+++ b/src/main/java/com/example/boxinglist/BoxingListService.java
@@ -1,0 +1,33 @@
+package com.example.boxinglist;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class BoxingListService {
+    private final BoxingListMapper boxingListMapper;
+
+    public BoxingListService(BoxingListMapper boxingListMapper) {
+
+        this.boxingListMapper = boxingListMapper;
+    }
+
+    public List<Boxer> findAll() {
+        return boxingListMapper.findAll();
+    }
+
+    public List<Boxer> findByNamesStartingWith(String startsWith) {
+        return boxingListMapper.findByNamesStartingWith(startsWith);
+    }
+
+    public Boxer findBoxer(int id) {
+        return boxingListMapper.findById(id)
+                .orElseThrow(() -> new BoxingListNotFoundException("Boxer with id " + id + " not found"));
+    }
+
+    public List<Boxer> findByNumberOfMatchesBetween(int minMatches, int maxMatches) {
+        return boxingListMapper.findByNumberOfMatchesBetween(minMatches, maxMatches);
+    }
+
+}

--- a/src/main/java/com/example/boxinglist/BoxinglistApplication.java
+++ b/src/main/java/com/example/boxinglist/BoxinglistApplication.java
@@ -4,10 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class BoxinglistApplication {
+public class BoxingListApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BoxinglistApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(BoxingListApplication.class, args);
+    }
 }

--- a/src/main/java/com/example/boxinglist/CoustomeExceptionHandler.java
+++ b/src/main/java/com/example/boxinglist/CoustomeExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.boxinglist;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestControllerAdvice
+public class CoustomeExceptionHandler {
+    @ExceptionHandler(BoxingListNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNameNotFoundException(
+            BoxingListNotFoundException e, HttpServletRequest request) {
+        Map body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=boxinglist
+spring.datasource.url=jdbc:mysql://localhost:3307/boxer_db
+spring.datasource.username=user
+spring.datasource.password=password


### PR DESCRIPTION
# 概要
READ処理の実装を行いました。

## 動作確認
### リクエスト
Method:GET
各検索項目は、全て下記の項目のようになる
- URL
- ステータスコード
- ボディ：ユーザーのリストを Json 形式で返す

#### 検索して全てのIDレコードを取得するAPI

- `http://localhost:8080/boxers`
- ステータスコード：200

#### クエリ文字列である文字から始まる文字を指定した アルファベットの一文字は、曖昧な適当な文字で終わるname で検索してレコードを取得するAPI

- `http://localhost:8080/findNames?startsWith=○`　※○：nameのアルファベットの頭文字を入力
- ステータスコード：200
- アルファベットの頭文字を入力時は、存在しない場合はステータスコード 404 を返しつつ、
"message""ボクシングリストに　○　から始まる文字のBoxerは見つかりません。"
- 空白を入力時、存在しない場合はステータスコード 404 を返しつつ、
"message""空白入力では、Boxerは検索できません。"

#### 指定した ID 検索してレコードを取得するAPI

- `http://localhost:8080/boxers/○` 　　　　　　　　　※○：idナンバーを入力
- ステータスコード：200
- ID が存在しない場合はステータスコード 404 を返す 
ボディ：ユーザーのリストを Json 形式で返す "message";"Boxer with id  not found",

#### 戦歴が〇〇戦以上〇〇以下のボクサーを検索してレコードを取得するAPI

- `http://localhost:8080/boxers/findByMatches?minMatches=〇〇&maxMatches=●●`
   ※〇〇は●●より小さい数字、●●は〇〇より大きい数字入力時、ステータスコード：200
- 〇〇は●●より大きい数字または同じ数字、●●は〇〇より小さい数字を入力時、
  "message";"指定された試合数範囲に該当するボクサーはいません。",を返しつつ、ステータスコード404 を返す
- 〇〇または●●が空白時、"message";”Bad Request”を返しつつ、ステータスコード400を返す